### PR TITLE
Use "windows-rs" instead of "winapi"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,12 @@ with_dbus = ["dbus"]
 mach = "0.3"
 libc = "0.2"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = [ "avrt", "errhandlingapi", "ntdef", "minwindef"] }
+[target.'cfg(target_os = "windows")'.dependencies.windows]
+version = "^0.32.0"
+features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@ cfg_if! {
         use rt_mach::demote_current_thread_from_real_time_internal;
         use rt_mach::RtPriorityHandleInternal;
     } else if #[cfg(target_os = "windows")] {
-        extern crate winapi;
         mod rt_win;
         use rt_win::promote_current_thread_to_real_time_internal;
         use rt_win::demote_current_thread_from_real_time_internal;


### PR DESCRIPTION
`windows-rs` [1] is becoming the more ergonomic contender for hitting
win32 APIs.

Unfortunately, both it and `winapi` are large dependencies that can
significantly impact compile times.
By porting this project to use `windows-rs`, we allow modern Windows
audio projects to significantly lower their compile times.

Related: since this uses _so little_ of the windows-rs API, I
optimistically set the dependency to be a caret requirement. This might
be a bit ambitious, but my thoughts on tradeoffs here are:
* There's relatively low risk of breakage, due to a very small amount of
  `windows-rs` being used.
* If there _is_ breakage, dependent crates can pin
  `audio_thread_priority`, and we can re-evaluate whether the caret
  requirement should be more strict.
* But, assuming no issues, then we can happily use the same version as
  the parent project, thereby avoiding compiling windows-rs twice.

Finally, there will still be projects who'd prefer the use of `winapi`:
perhaps they can remain on `audio_thread_priority < 0.24`, and that
will be a sufficient solution?

[1] https://github.com/microsoft/windows-rs