### PR TITLE
rt_mach: Calculation computation time as half of constraint, per macOS 12.

### DIFF
--- a/src/rt_mach.rs
+++ b/src/rt_mach.rs
@@ -136,9 +136,10 @@ pub fn promote_current_thread_to_real_time_internal(
 
         let ms2abs: f32 = ((timebase_info.denom as f32) / timebase_info.numer as f32) * 1000000.;
 
+        // Computation time is half of constraint, per macOS 12 behaviour.
         time_constraints = thread_time_constraint_policy_data_t {
             period: (cb_duration * ms2abs) as u32,
-            computation: (0.3 * ms2abs) as u32, // fixed 300us computation time
+            computation: (cb_duration / 2.0 * ms2abs) as u32,
             constraint: (cb_duration * ms2abs) as u32,
             preemptible: 1, // true
         };


### PR DESCRIPTION
From macOS 12 (XNU 8019.41.5), the computation time must be at least
half the constraint time: https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/kern/thread_policy.c#L389