### PR TITLE
Restore optional ability to build against "winapi" instead of "windows-rs".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ nix = "0.15.0"
 [features]
 terminal-logging = ["simple_logger"]
 with_dbus = ["dbus"]
-default = ["with_dbus"]
+default = ["with_dbus", "windows"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach = "0.3"
@@ -34,6 +34,16 @@ features = [
     "Win32_Foundation",
     "Win32_System_Threading",
 ]
+optional = true
+
+[target.'cfg(target_os = "windows")'.dependencies.winapi]
+version = "0.3"
+features = [
+    "avrt",
+    "errhandlingapi",
+    "minwindef"
+]
+optional = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"

--- a/src/rt_win.rs
+++ b/src/rt_win.rs
@@ -1,5 +1,39 @@
-use windows::Win32::Foundation;
-use windows::Win32::System::Threading;
+#[cfg(feature = "windows")]
+mod os {
+    pub use windows::Win32::Foundation::GetLastError;
+    pub use windows::Win32::Foundation::HANDLE;
+    pub use windows::Win32::Foundation::PSTR;
+    pub use windows::Win32::System::Threading::{
+        AvRevertMmThreadCharacteristics, AvSetMmThreadCharacteristicsA,
+    };
+
+    pub fn ok(rv: windows::Win32::Foundation::BOOL) -> bool {
+        rv.as_bool()
+    }
+
+    pub fn invalid_handle(handle: HANDLE) -> bool {
+        handle.is_invalid()
+    }
+}
+#[cfg(feature = "winapi")]
+mod os {
+    pub use winapi::shared::ntdef::HANDLE;
+    pub use winapi::um::avrt::{AvRevertMmThreadCharacteristics, AvSetMmThreadCharacteristicsA};
+    pub use winapi::um::errhandlingapi::GetLastError;
+
+    pub fn ok(rv: winapi::shared::minwindef::BOOL) -> bool {
+        rv != 0
+    }
+
+    #[allow(non_snake_case)]
+    pub fn PSTR(ptr: *const u8) -> *const i8 {
+        ptr as _
+    }
+
+    pub fn invalid_handle(handle: HANDLE) -> bool {
+        handle.is_null()
+    }
+}
 
 use crate::AudioThreadPriorityError;
 
@@ -8,11 +42,11 @@ use log::info;
 #[derive(Debug)]
 pub struct RtPriorityHandleInternal {
     mmcss_task_index: u32,
-    task_handle: Foundation::HANDLE,
+    task_handle: os::HANDLE,
 }
 
 impl RtPriorityHandleInternal {
-    pub fn new(mmcss_task_index: u32, task_handle: Foundation::HANDLE) -> RtPriorityHandleInternal {
+    pub fn new(mmcss_task_index: u32, task_handle: os::HANDLE) -> RtPriorityHandleInternal {
         RtPriorityHandleInternal {
             mmcss_task_index,
             task_handle,
@@ -23,11 +57,11 @@ impl RtPriorityHandleInternal {
 pub fn demote_current_thread_from_real_time_internal(
     rt_priority_handle: RtPriorityHandleInternal,
 ) -> Result<(), AudioThreadPriorityError> {
-    let rv = unsafe { Threading::AvRevertMmThreadCharacteristics(rt_priority_handle.task_handle) };
-    if !rv.as_bool() {
+    let rv = unsafe { os::AvRevertMmThreadCharacteristics(rt_priority_handle.task_handle) };
+    if !os::ok(rv) {
         return Err(AudioThreadPriorityError::new(&format!(
             "Unable to restore the thread priority ({:?})",
-            unsafe { Foundation::GetLastError() }
+            unsafe { os::GetLastError() }
         )));
     }
 
@@ -45,18 +79,14 @@ pub fn promote_current_thread_to_real_time_internal(
 ) -> Result<RtPriorityHandleInternal, AudioThreadPriorityError> {
     let mut task_index = 0u32;
 
-    let handle = unsafe {
-        Threading::AvSetMmThreadCharacteristicsA(
-            Foundation::PSTR("Audio\0".as_ptr() as _),
-            &mut task_index,
-        )
-    };
+    let handle =
+        unsafe { os::AvSetMmThreadCharacteristicsA(os::PSTR("Audio\0".as_ptr()), &mut task_index) };
     let handle = RtPriorityHandleInternal::new(task_index, handle);
 
-    if handle.task_handle.is_invalid() {
+    if os::invalid_handle(handle.task_handle) {
         return Err(AudioThreadPriorityError::new(&format!(
             "Unable to restore the thread priority ({:?})",
-            unsafe { Foundation::GetLastError() }
+            unsafe { os::GetLastError() }
         )));
     }
 


### PR DESCRIPTION
As of now, "audio_thread_priority" would be the only consumer of "windows-rs" in Gecko.  Unfortunately the vendored crates for "windows-rs" total ~260MB (all other vendored crates total ~313MB), which makes it difficult to import.

Until other crates in Gecko are using "windows-rs", it'd be preferable to continue using "winapi".  It's possible the size issue could also be addressed by switching from "windows-rs" to "windows-sys", but I haven't investigated that option.

Follow up to pull #10.
