### PR TITLE
chore: Switch from `mach` to `mach2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ with_dbus = ["dbus"]
 default = ["with_dbus"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mach = "0.3"
+mach2 = "0.4"
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ cfg_if! {
         mod rt_mach;
 #[allow(unused, non_camel_case_types, non_snake_case, non_upper_case_globals)]
         mod mach_sys;
-        extern crate mach;
+        extern crate mach2;
         extern crate libc;
         use rt_mach::promote_current_thread_to_real_time_internal;
         use rt_mach::demote_current_thread_from_real_time_internal;

--- a/src/rt_mach.rs
+++ b/src/rt_mach.rs
@@ -2,10 +2,10 @@ use crate::mach_sys::*;
 use crate::AudioThreadPriorityError;
 use libc::{pthread_self, pthread_t};
 use log::info;
-use mach::kern_return::{kern_return_t, KERN_SUCCESS};
-use mach::mach_time::{mach_timebase_info, mach_timebase_info_data_t};
-use mach::message::mach_msg_type_number_t;
-use mach::port::mach_port_t;
+use mach2::kern_return::{kern_return_t, KERN_SUCCESS};
+use mach2::mach_time::{mach_timebase_info, mach_timebase_info_data_t};
+use mach2::message::mach_msg_type_number_t;
+use mach2::port::mach_port_t;
 use std::mem::size_of;
 
 extern "C" {


### PR DESCRIPTION
`mach` is unmaintained, and this is one of the last two packages in Gecko depending on it:
```
Crate:     mach
Version:   0.3.2
Warning:   unmaintained
Title:     mach is unmaintained
Date:      2020-07-14
ID:        RUSTSEC-2020-0168
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0168
Dependency tree:
mach 0.3.2
├── cubeb-coreaudio 0.1.0
│   └── gkrust-shared 0.1.0
│       ├── gkrust-gtest 0.1.0
│       └── gkrust 0.1.0
└── audio_thread_priority 0.32.0
    ├── gkrust-shared 0.1.0
    ├── audioipc2-server 0.6.0
    │   └── gkrust-shared 0.1.0
    ├── audioipc2-client 0.6.0
    │   └── gkrust-shared 0.1.0
    └── audioipc2 0.6.0
        ├── audioipc2-server 0.6.0
        └── audioipc2-client 0.6.0
```