### PR TITLE
Add native Android support.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,10 @@ jobs:
         rustup component add rustfmt --toolchain ${{ matrix.rust }}
         rustup component add clippy --toolchain ${{ matrix.rust }}
 
+    - name: Install Rust (Android target)
+      run: rustup target add x86_64-linux-android --toolchain ${{ matrix.rust }}
+      if: matrix.os == 'ubuntu-24.04'
+
     - name: Install Dependencies (Linux)
       run: sudo apt-get update && sudo apt-get install libpulse-dev pulseaudio libdbus-1-dev
       if: matrix.os == 'ubuntu-24.04'
@@ -35,6 +39,11 @@ jobs:
     - name: Build
       shell: bash
       run: rustup run ${{ matrix.rust }} cargo build --all
+
+    - name: Build (Android)
+      shell: bash
+      run: rustup run ${{ matrix.rust }} cargo build --target x86_64-linux-android --all
+      if: matrix.os == 'ubuntu-24.04'
 
     - name: Test
       shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "audio_thread_priority"
 version = "0.33.0"
 authors = ["Paul Adenot <paul@paul.cx>"]
-description = "Bump a thread to real-time priority, for audio work, on Linux, Windows and macOS"
+description = "Bump a thread to real-time priority, for audio work, on Linux, Android, Windows and macOS"
 license = "MPL-2.0"
 repository = "https://github.com/padenot/audio_thread_priority"
 edition = "2018"
@@ -41,3 +41,6 @@ libc = "0.2"
 [target.'cfg(target_os = "linux")'.dependencies.dbus]
 version = "0.6.4"
 optional = true
+
+[target.'cfg(target_os = "android")'.dependencies]
+libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,11 @@ cfg_if! {
         #[no_mangle]
         /// Size of a RtPriorityThreadInfo or atp_thread_info struct, for use in FFI.
         pub static ATP_THREAD_INFO_SIZE: usize = std::mem::size_of::<RtPriorityThreadInfo>();
+    } else if #[cfg(target_os = "android")] {
+        mod rt_android;
+        use rt_android::promote_current_thread_to_real_time_internal;
+        use rt_android::demote_current_thread_from_real_time_internal;
+        use rt_android::RtPriorityHandleInternal;
     } else {
         // blanket implementations for Android, Linux Desktop without dbus and others
         pub struct RtPriorityHandleInternal {}
@@ -480,7 +485,7 @@ pub fn promote_current_thread_to_real_time(
 ///
 /// # Return value
 ///
-/// `Ok` in scase of success, `Err` otherwise.
+/// `Ok` in case of success, `Err` otherwise.
 pub fn demote_current_thread_from_real_time(
     handle: RtPriorityHandle,
 ) -> Result<(), AudioThreadPriorityError> {

--- a/src/rt_android.rs
+++ b/src/rt_android.rs
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate libc;
+use crate::AudioThreadPriorityError;
+use std::convert::TryInto;
+
+// https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/os/Process.java#474
+const THREAD_PRIORITY_URGENT_AUDIO: libc::c_int = -19;
+
+#[derive(Debug)]
+pub struct RtPriorityHandleInternal {
+    previous_priority: libc::c_int,
+}
+
+pub fn promote_current_thread_to_real_time_internal(
+    _: u32,
+    _: u32,
+) -> Result<RtPriorityHandleInternal, AudioThreadPriorityError> {
+    // Android's Process.setThreadPriority() ultimately calls setpriority().
+    // See https://android.googlesource.com/platform/frameworks/base/+/master/core/jni/android_util_Process.cpp#543
+    // and https://android.googlesource.com/platform/system/core/+/master/libutils/Threads.cpp#312
+
+    // Per https://github.com/android/ndk/issues/1255
+    // and https://android.googlesource.com/platform/bionic/+/master/libc/include/pthread.h#388,
+    // it's acceptable to call setpriority() directly for native threads.
+
+    let who = unsafe { libc::gettid().try_into().unwrap() };
+
+    unsafe { (*libc::__errno()) = 0 };
+    let previous_priority = unsafe { libc::getpriority(libc::PRIO_PROCESS, who) };
+    if previous_priority == -1 && unsafe { *libc::__errno() } != 0 {
+        return Err(AudioThreadPriorityError::new(
+            "Failed to get current thread priority",
+        ));
+    }
+
+    let r = unsafe { libc::setpriority(libc::PRIO_PROCESS, who, THREAD_PRIORITY_URGENT_AUDIO) };
+    if r < 0 {
+        return Err(AudioThreadPriorityError::new(
+            "Failed to set current thread priority",
+        ));
+    }
+
+    Ok(RtPriorityHandleInternal { previous_priority })
+}
+
+pub fn demote_current_thread_from_real_time_internal(
+    h: RtPriorityHandleInternal,
+) -> Result<(), AudioThreadPriorityError> {
+    let who = unsafe { libc::gettid().try_into().unwrap() };
+    let r = unsafe { libc::setpriority(libc::PRIO_PROCESS, who, h.previous_priority) };
+    if r < 0 {
+        return Err(AudioThreadPriorityError::new(
+            "Failed to demote thread priority",
+        ));
+    }
+    Ok(())
+}


### PR DESCRIPTION
We can promote/demote native Android threads directly without involving `JNI` and `android.os.Process#setThreadPriority` by calling [`setpriority`](https://linux.die.net/man/2/setpriority) in `bionic` directly.

We need to get #31 landed to fix the CI runners, then this will require a small tweak for the Android CI build addition.

Closes issue #24.