### PR TITLE
Revert "build: upgrade `windows-sys` 0.52 → 0.59"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ mach2 = "0.4"
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.59"
+version = "0.52"
 features = [
     "Win32_Foundation",
     "Win32_System_LibraryLoader",

--- a/src/rt_win.rs
+++ b/src/rt_win.rs
@@ -137,7 +137,7 @@ mod avrt_lib {
             let task_handle = unsafe {
                 (self.av_set_mm_thread_characteristics_w)(task_name, &mut mmcss_task_index)
             };
-            win32_error_if(task_handle.is_null())?;
+            win32_error_if(task_handle == 0)?;
             Ok((mmcss_task_index, task_handle))
         }
 
@@ -174,7 +174,7 @@ mod win32_utils {
     impl OwnedLibrary {
         pub(super) fn try_new(lib_file_name: PCWSTR) -> Result<Self, WIN32_ERROR> {
             let module = unsafe { LoadLibraryW(lib_file_name) };
-            win32_error_if(module.is_null())?;
+            win32_error_if(module == 0)?;
             Ok(Self(module))
         }
 
@@ -201,9 +201,6 @@ mod win32_utils {
             }
         }
     }
-
-    unsafe impl Send for OwnedLibrary {}
-    unsafe impl Sync for OwnedLibrary {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Revert windows-sys upgrade until Gecko catches up, otherwise we end up with duplicate crate imports.

This reverts commit b21650ff55da37f829c0c46b18ea491a43535d2b.