### PR TITLE
Allow building the macOS backend for iOS targets.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ terminal-logging = ["simple_logger"]
 with_dbus = ["dbus"]
 default = ["with_dbus"]
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 mach2 = "0.4"
 libc = "0.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ impl Error for AudioThreadPriorityError {
 }
 
 cfg_if! {
-    if #[cfg(target_os = "macos")] {
+    if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         mod rt_mach;
         extern crate mach2;
         extern crate libc;


### PR DESCRIPTION
Untested aside from cross-compiling to `aarch64-apple-ios`, but this might be all that's needed for issue #39. 