### PR TITLE
Expose target pid on Linux.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,10 @@ cfg_if! {
             pub fn deserialize(_: [u8; 1]) -> Self {
                 RtPriorityThreadInfo{_dummy: 0}
             }
+            /// Returns the PID of the process containing the thread (fallback: always -1).
+            pub fn pid(&self) -> i32 {
+                -1
+            }
         }
         /// Fallback implementation that performs no operation for unsupported platforms.
         pub fn promote_current_thread_to_real_time_internal(_: u32, audio_samplerate_hz: u32) -> Result<RtPriorityHandle, AudioThreadPriorityError> {

--- a/src/rt_linux.rs
+++ b/src/rt_linux.rs
@@ -62,6 +62,10 @@ impl RtPriorityThreadInfoInternal {
     pub fn deserialize(bytes: [u8; std::mem::size_of::<Self>()]) -> Self {
         unsafe { std::mem::transmute::<[u8; std::mem::size_of::<Self>()], Self>(bytes) }
     }
+    /// Returns the PID of the process containing the thread.
+    pub fn pid(&self) -> libc::pid_t {
+        self.pid
+    }
 }
 
 impl PartialEq for RtPriorityThreadInfoInternal {


### PR DESCRIPTION
We want to use this in [AudioIPC on the server side](https://github.com/mozilla/audioipc/blob/d59b317cac1b4bb3f56b3faf02351336a388a398/server/src/server.rs#L675) to verify the target pid supplied by the client matches the trusted pid supplied by Gecko during client setup.  There's a separate change for AudioIPC to enable this coming shortly.