### PR TITLE
bump windows-sys dependency to 0.61.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ mach2 = "0.4"
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.52"
+version = "0.61.2"
 features = [
     "Win32_Foundation",
     "Win32_System_LibraryLoader",


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=2033393 I need the `windows-sys` crate bumped to version `0.61.2` to not have different versions of the crate in the repository.

@padenot can you please review / merge / release so that I can finish my patch? Thanks!